### PR TITLE
Fix inability to get version from package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const Routes = require('./lib/routes')
 const PushSubscriptions = require('./lib/pushSubscriptions')
 
 const request = require('request-promise')
-const version = require('./package').version
+const version = require('./package.json').version
 
 const strava = {}
 


### PR DESCRIPTION
`require('./package')` alone fails in some cases (i.e. Node versions), because that's not a valid package. Specifying the file ending fixes this issue and should be version independant. For reference and possible other ways of obtaining the version from code: https://stackoverflow.com/questions/9153571/is-there-a-way-to-get-version-from-package-json-in-nodejs-code