### PR TITLE
Support creating/updating sport type of activity

### DIFF
--- a/lib/activities.js
+++ b/lib/activities.js
@@ -14,6 +14,7 @@ var _qsAllowedProps = [
 var _createAllowedProps = [
   'name',
   'type',
+  'sport_type',
   'start_date_local',
   'elapsed_time',
   'description',
@@ -24,6 +25,7 @@ var _createAllowedProps = [
 var _updateAllowedProps = [
   'name',
   'type',
+  'sport_type',
   'private',
   'commute',
   'trainer',

--- a/test/activities.js
+++ b/test/activities.js
@@ -97,6 +97,27 @@ describe('activities_test', function () {
     })
   })
 
+  describe('#updateSportType()', function () {
+    it('should update the sport type of an activity', function (done) {
+      var sport_type = 'MountainBikeRide'
+      var args = {
+        id: testActivity.id,
+        sport_type: sport_type
+      }
+
+      strava.activities.update(args, function (err, payload) {
+        if (!err) {
+          (payload.resource_state).should.be.exactly(3);
+          (payload.sport_type).should.be.exactly(sport_type)
+        } else {
+          console.log(err)
+        }
+
+        done()
+      })
+    })
+  })
+
   // TODO can't test b/c this requires premium account
   describe('#listZones()', function () {
     xit('should list heart rate and power zones relating to activity', function (done) {


### PR DESCRIPTION
Strava [recently introduced](https://developers.strava.com/docs/changelog/) a new activity property `sport_type` of type [SportType](https://developers.strava.com/docs/reference/#api-models-SportType) that can be used to indicate the sport type when [creating](https://developers.strava.com/docs/reference/#api-Activities-createActivity) or [updating](https://developers.strava.com/docs/reference/#api-Activities-updateActivityById) activities:

> An enumeration of the sport types an activity may have. Distinct from ActivityType in that it has new types (e.g. MountainBikeRide)

> May be one of the following values: AlpineSki, BackcountrySki, Canoeing, Crossfit, EBikeRide, Elliptical, EMountainBikeRide, Golf, GravelRide, Handcycle, Hike, IceSkate, InlineSkate, Kayaking, Kitesurf, MountainBikeRide, NordicSki, Ride, RockClimbing, RollerSki, Rowing, Run, Sail, Skateboard, Snowboard, Snowshoe, Soccer, StairStepper, StandUpPaddling, Surfing, Swim, TrailRun, Velomobile, VirtualRide, VirtualRun, Walk, WeightTraining, Wheelchair, Windsurf, Workout, Yoga

Test note: I have added a test case for testing updating a sport type, but I have not executed the test suite... (I don't want to risk the data in my Strava account nor the account itself). However, I did successfully update all (several hundreds) previously recorded rides on my MTB bikes to have the new sport type `MountainBikeRide`. I verified random samples (checked that its icon is now a bike with a mountain on top and that the ride is listed as a "Mountain Bike Ride").



Fixes #130 