### PR TITLE
fix: remove prototype suffix from authenticated athlete endpoint

### DIFF
--- a/lib/athlete.js
+++ b/lib/athlete.js
@@ -19,7 +19,7 @@ var _updateAllowedProps = [
 
 //= ==== athlete endpoint =====
 athlete.prototype.get = function (args, done) {
-  var endpoint = 'athlete.prototype'
+  var endpoint = 'athlete'
   return this.client.getEndpoint(endpoint, args, done)
 }
 athlete.prototype.listActivities = function (args, done) {


### PR DESCRIPTION
Oddly the `athlete.prototype` endpoint works, but could break in the future so I opted to change it.