### PR TITLE
remove endpoints that are not present at the Strava API anymore

### DIFF
--- a/lib/clubs.js
+++ b/lib/clubs.js
@@ -21,20 +21,8 @@ clubs.prototype.listMembers = function (args, done) {
 clubs.prototype.listActivities = function (args, done) {
   return this._listHelper('activities', args, done)
 }
-clubs.prototype.listAnnouncements = function (args, done) {
-  return this._listHelper('announcements', args, done)
-}
-clubs.prototype.listEvents = function (args, done) {
-  return this._listHelper('group_events', args, done)
-}
 clubs.prototype.listAdmins = function (args, done) {
   return this._listHelper('admins', args, done)
-}
-clubs.prototype.joinClub = function (args, done) {
-  return this._listHelper('join', args, done)
-}
-clubs.prototype.leaveClub = function (args, done) {
-  return this._listHelper('leave', args, done)
 }
 //= ==== clubs endpoint =====
 


### PR DESCRIPTION
As stated in issue #136 these endpoints cannot be reached on the API anymore and are being removed from here also. @markstos could you please take a look on it?