### PR TITLE
Add missing return values from DetailedActivityResponse

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -282,6 +282,8 @@ export interface DetailedActivityResponse {
   description?: string;
   calories?: number;
   private_notes?: string;
+  start_latlng?: Array<number>;
+  end_latlng?: Array<number>;
 }
 
 export interface ActivitiesRoutes {


### PR DESCRIPTION
Following https://github.com/node-strava/node-strava-v3/issues/149#issue-2094209051
From the [API](https://developers.strava.com/docs/reference/#api-models-DetailedActivity)

- `start_latlng`
- `end_latlng`