### PR TITLE
Remove deprecated .listLeaderboard() endpoint + Update on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,11 +283,7 @@ See Strava API docs for returned data structures.
 * `strava.clubs.get(args,done)`
 * `strava.clubs.listMembers(args,done)`
 * `strava.clubs.listActivities(args,done)`
-* `strava.clubs.listAnnouncements(args,done)`
-* `strava.clubs.listEvents(args,done)`
 * `strava.clubs.listAdmins(args,done)`
-* `strava.clubs.joinClub(args,done)`
-* `strava.clubs.leaveClub(args,done)`
 
 #### Gear
 
@@ -318,7 +314,6 @@ use OAuth, they are not available on the `client` object.
  * `strava.segments.get(args,done)`
  * `strava.segments.listStarred(args,done)`
  * `strava.segments.listEfforts(args,done)`
- * `strava.segments.listLeaderboard(args,done)`
  * `strava.segments.explore(args,done)` *Expects arg `bounds` as a comma separated string, for two points describing a rectangular boundary for the search: `"southwest corner latitutde, southwest corner longitude, northeast corner latitude, northeast corner longitude"`*.
 
 #### Segment Efforts

--- a/lib/clubs.js
+++ b/lib/clubs.js
@@ -21,20 +21,8 @@ clubs.prototype.listMembers = function (args, done) {
 clubs.prototype.listActivities = function (args, done) {
   return this._listHelper('activities', args, done)
 }
-clubs.prototype.listAnnouncements = function (args, done) {
-  return this._listHelper('announcements', args, done)
-}
-clubs.prototype.listEvents = function (args, done) {
-  return this._listHelper('group_events', args, done)
-}
 clubs.prototype.listAdmins = function (args, done) {
   return this._listHelper('admins', args, done)
-}
-clubs.prototype.joinClub = function (args, done) {
-  return this._listHelper('join', args, done)
-}
-clubs.prototype.leaveClub = function (args, done) {
-  return this._listHelper('leave', args, done)
 }
 //= ==== clubs endpoint =====
 

--- a/lib/segments.js
+++ b/lib/segments.js
@@ -76,10 +76,6 @@ segments.prototype.listEfforts = function (args, done) {
   return this._listHelper('all_efforts', args, done)
 }
 
-segments.prototype.listLeaderboard = function (args, done) {
-  return this._listHelper('leaderboard', args, done)
-}
-
 segments.prototype.explore = function (args, done) {
   var qs = this.client.getQS(_qsAllowedProps, args)
   var endpoint = 'segments/explore?' + qs

--- a/test/segments.js
+++ b/test/segments.js
@@ -104,25 +104,6 @@ describe('segments_test', function () {
     })
   })
 
-  describe('#listLeaderboard()', function () {
-    it('should list leaderboard for segment', function (done) {
-      strava.segments.listLeaderboard({
-        id: _sampleSegment.id,
-        page: 1,
-        per_page: 4,
-        gender: 'M'
-      }, function (err, payload) {
-        if (!err) {
-          payload.entries.should.be.instanceof(Array)
-        } else {
-          console.log(err)
-        }
-
-        done()
-      })
-    })
-  })
-
   describe('#explore()', function () {
     it('should return up to 10 segments w/i the given bounds', function (done) {
       strava.segments.explore({


### PR DESCRIPTION
I've removed .listLeaderboard() endpoint which is no longer supported by the API + I've updated the README file with the changes on issue #148