### PR TITLE
Remove Callback Usage and Embrace Promise-Based API

### DIFF
--- a/lib/activities.js
+++ b/lib/activities.js
@@ -34,21 +34,23 @@ var _updateAllowedProps = [
 ]
 
 //= ==== activities endpoint =====
-activities.prototype.get = function (args, done) {
+activities.prototype.get = function (args) {
   var qs = this.client.getQS(_qsAllowedProps, args)
 
   _requireActivityId(args)
 
   var endpoint = 'activities/' + args.id + '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
-activities.prototype.create = function (args, done) {
+
+activities.prototype.create = function (args) {
   var endpoint = 'activities'
 
   args.body = this.client.getRequestBodyObj(_createAllowedProps, args)
-  return this.client.postEndpoint(endpoint, args, done)
+  return this.client.postEndpoint(endpoint, args)
 }
-activities.prototype.update = function (args, done) {
+
+activities.prototype.update = function (args) {
   var form = this.client.getRequestBodyObj(_updateAllowedProps, args)
 
   _requireActivityId(args)
@@ -57,36 +59,36 @@ activities.prototype.update = function (args, done) {
 
   args.form = form
 
-  return this.client.putEndpoint(endpoint, args, done)
+  return this.client.putEndpoint(endpoint, args)
 }
 
-activities.prototype.listZones = function (args, done) {
+activities.prototype.listZones = function (args) {
   _requireActivityId(args)
 
   var endpoint = 'activities/' + args.id + '/zones'
 
-  return this._listHelper(endpoint, args, done)
+  return this._listHelper(endpoint, args)
 }
-activities.prototype.listLaps = function (args, done) {
+activities.prototype.listLaps = function (args) {
   _requireActivityId(args)
 
   var endpoint = 'activities/' + args.id + '/laps'
 
-  return this._listHelper(endpoint, args, done)
+  return this._listHelper(endpoint, args)
 }
-activities.prototype.listComments = function (args, done) {
+activities.prototype.listComments = function (args) {
   _requireActivityId(args)
 
   var endpoint = 'activities/' + args.id + '/comments'
 
-  return this._listHelper(endpoint, args, done)
+  return this._listHelper(endpoint, args)
 }
-activities.prototype.listKudos = function (args, done) {
+activities.prototype.listKudos = function (args) {
   _requireActivityId(args)
 
   var endpoint = 'activities/' + args.id + '/kudos'
 
-  return this._listHelper(endpoint, args, done)
+  return this._listHelper(endpoint, args)
 }
 //= ==== activities endpoint =====
 
@@ -97,11 +99,11 @@ var _requireActivityId = function (args) {
   }
 }
 
-activities.prototype._listHelper = function (endpoint, args, done) {
+activities.prototype._listHelper = function (endpoint, args) {
   var qs = this.client.getPaginationQS(args)
 
   endpoint += '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 //= ==== helpers =====
 

--- a/lib/athlete.js
+++ b/lib/athlete.js
@@ -18,39 +18,43 @@ var _updateAllowedProps = [
 ]
 
 //= ==== athlete endpoint =====
-athlete.prototype.get = function (args, done) {
+athlete.prototype.get = function (args) {
   var endpoint = 'athlete'
-  return this.client.getEndpoint(endpoint, args, done)
-}
-athlete.prototype.listActivities = function (args, done) {
-  return this._listHelper('activities', args, done)
-}
-athlete.prototype.listClubs = function (args, done) {
-  return this._listHelper('clubs', args, done)
-}
-athlete.prototype.listRoutes = function (args, done) {
-  return this._listHelper('routes', args, done)
-}
-athlete.prototype.listZones = function (args, done) {
-  return this._listHelper('zones', args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 
-athlete.prototype.update = function (args, done) {
+athlete.prototype.listActivities = function (args) {
+  return this._listHelper('activities', args)
+}
+
+athlete.prototype.listClubs = function (args) {
+  return this._listHelper('clubs', args)
+}
+
+athlete.prototype.listRoutes = function (args) {
+  return this._listHelper('routes', args)
+}
+
+athlete.prototype.listZones = function (args) {
+  return this._listHelper('zones', args)
+}
+
+athlete.prototype.update = function (args) {
   var endpoint = 'athlete'
   var form = this.client.getRequestBodyObj(_updateAllowedProps, args)
 
   args.form = form
-  return this.client.putEndpoint(endpoint, args, done)
+  return this.client.putEndpoint(endpoint, args)
 }
 //= ==== athlete.prototype endpoint =====
 
 //= ==== helpers =====
-athlete.prototype._listHelper = function (listType, args, done) {
+athlete.prototype._listHelper = function (listType, args) {
   var endpoint = 'athlete/'
   var qs = this.client.getQS(_qsAllowedProps, args)
 
   endpoint += listType + '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 //= ==== helpers =====
 

--- a/lib/athletes.js
+++ b/lib/athletes.js
@@ -3,16 +3,17 @@ var athletes = function (client) {
 }
 
 //= ==== athletes endpoint =====
-athletes.prototype.get = function (args, done) {
-  return this._listHelper('', args, done)
+athletes.prototype.get = function (args) {
+  return this._listHelper('', args)
 }
-athletes.prototype.stats = function (args, done) {
-  return this._listHelper('stats', args, done)
+
+athletes.prototype.stats = function (args) {
+  return this._listHelper('stats', args)
 }
 //= ==== athletes endpoint =====
 
 //= ==== helpers =====
-athletes.prototype._listHelper = function (listType, args, done) {
+athletes.prototype._listHelper = function (listType, args) {
   var endpoint = 'athletes/'
   var qs = this.client.getPaginationQS(args)
 
@@ -22,7 +23,7 @@ athletes.prototype._listHelper = function (listType, args, done) {
   }
 
   endpoint += args.id + '/' + listType + '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 //= ==== helpers =====
 

--- a/lib/clubs.js
+++ b/lib/clubs.js
@@ -3,44 +3,44 @@ var clubs = function (client) {
 }
 
 //= ==== clubs endpoint =====
-clubs.prototype.get = function (args, done) {
+clubs.prototype.get = function (args) {
   var endpoint = 'clubs/'
 
   // require club id
   if (typeof args.id === 'undefined') {
-    const err = { msg: 'args must include a club id' }
-    return done(err)
+    throw new Error('args must include a club id')
   }
 
   endpoint += args.id
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
-clubs.prototype.listMembers = function (args, done) {
-  return this._listHelper('members', args, done)
+
+clubs.prototype.listMembers = function (args) {
+  return this._listHelper('members', args)
 }
-clubs.prototype.listActivities = function (args, done) {
-  return this._listHelper('activities', args, done)
+
+clubs.prototype.listActivities = function (args) {
+  return this._listHelper('activities', args)
 }
-clubs.prototype.listAdmins = function (args, done) {
-  return this._listHelper('admins', args, done)
+
+clubs.prototype.listAdmins = function (args) {
+  return this._listHelper('admins', args)
 }
 //= ==== clubs endpoint =====
 
 //= ==== helpers =====
-clubs.prototype._listHelper = function (listType, args, done) {
+clubs.prototype._listHelper = function (listType, args) {
   var endpoint = 'clubs/'
   var err = null
   var qs = this.client.getPaginationQS(args)
 
   // require club id
   if (typeof args.id === 'undefined') {
-    err = { 'msg': 'args must include a club id' }
-    return done(err)
+    throw new Error('args must include a club id')
   }
 
   endpoint += args.id + '/' + listType + '?' + qs
-
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 //= ==== helpers =====
 

--- a/lib/gear.js
+++ b/lib/gear.js
@@ -2,7 +2,7 @@ var gear = function (client) {
   this.client = client
 }
 
-gear.prototype.get = function (args, done) {
+gear.prototype.get = function (args) {
   var endpoint = 'gear/'
 
   // require gear id
@@ -11,7 +11,7 @@ gear.prototype.get = function (args, done) {
   }
 
   endpoint += args.id
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 
 module.exports = gear

--- a/lib/pushSubscriptions.js
+++ b/lib/pushSubscriptions.js
@@ -13,9 +13,9 @@ var _allowedPostProps = [
   'verify_token'
 ]
 
-pushSubscriptions.prototype.create = function (args, done) {
+pushSubscriptions.prototype.create = function (args) {
   if (typeof args.callback_url === 'undefined') {
-    return done({ 'msg': 'required args missing' })
+    throw new Error('required args missing')
   }
 
   // The Strava API currently only has one valid value for these,
@@ -39,10 +39,10 @@ pushSubscriptions.prototype.create = function (args, done) {
     url: 'push_subscriptions',
     method: 'POST',
     form: args.body
-  }, done)
+  })
 }
 
-pushSubscriptions.prototype.list = function (done) {
+pushSubscriptions.prototype.list = function () {
   var qs = this.client.getQS(['client_secret', 'client_id'], {
     client_secret: authenticator.getClientSecret(),
     client_id: authenticator.getClientId()
@@ -51,13 +51,13 @@ pushSubscriptions.prototype.list = function (done) {
     headers: { Authorization: null },
     baseUrl: this.baseUrl,
     url: 'push_subscriptions?' + qs
-  }, done)
+  })
 }
 
-pushSubscriptions.prototype.delete = function (args, done) {
+pushSubscriptions.prototype.delete = function (args) {
   // require subscription id
   if (typeof args.id === 'undefined') {
-    return done({ msg: 'args must include a push subscription id' })
+    throw new Error('args must include a push subscription id')
   }
 
   var qs = this.client.getQS(['client_secret', 'client_id'], {
@@ -70,7 +70,7 @@ pushSubscriptions.prototype.delete = function (args, done) {
     baseUrl: this.baseUrl,
     url: 'push_subscriptions/' + args.id + '?' + qs,
     method: 'DELETE'
-  }, done)
+  })
 }
 
 module.exports = pushSubscriptions

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -5,22 +5,22 @@ var routes = function (client) {
 var _qsAllowedProps = []
 
 //= ==== routes endpoint =====
-routes.prototype.get = function (args, done) {
+routes.prototype.get = function (args) {
   var endpoint = 'routes/'
   var qs = this.client.getQS(_qsAllowedProps, args)
 
   _requireRouteId(args)
 
   endpoint += args.id + '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 
-routes.prototype.getFile = function (args, done) {
+routes.prototype.getFile = function (args) {
   var endpoint = 'routes/'
 
   _requireRouteId(args)
 
-  this._getFileHelper(endpoint, args, done)
+  return this._getFileHelper(endpoint, args)
 }
 //= ==== routes endpoint =====
 
@@ -31,11 +31,11 @@ var _requireRouteId = function (args) {
   }
 }
 
-routes.prototype._getFileHelper = function (endpoint, args, done) {
+routes.prototype._getFileHelper = function (endpoint, args) {
   var qs = this.client.getQS(_qsAllowedProps, args)
-
   endpoint += args.id + `/export_${args.file_type}` + '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+
+  return this.client.getEndpoint(endpoint, args)
 }
 //= ==== helpers =====
 

--- a/lib/runningRaces.js
+++ b/lib/runningRaces.js
@@ -6,23 +6,23 @@ var _qsAllowedProps = [
   'year'
 ]
 
-runningRaces.prototype.get = function (args, done) {
+runningRaces.prototype.get = function (args) {
   var endpoint = 'running_races/'
 
   // require running race id
   if (typeof args.id === 'undefined') {
-    throw new Error('args must include an race id')
+    throw new Error('args must include a race id')
   }
 
   endpoint += args.id
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 
-runningRaces.prototype.listRaces = function (args, done) {
+runningRaces.prototype.listRaces = function (args) {
   var qs = this.client.getQS(_qsAllowedProps, args)
   var endpoint = 'running_races?' + qs
 
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 
 module.exports = runningRaces

--- a/lib/segmentEfforts.js
+++ b/lib/segmentEfforts.js
@@ -3,7 +3,7 @@ var segmentEfforts = function (client) {
 }
 
 //= ==== segment_efforts endpoint =====
-segmentEfforts.prototype.get = function (args, done) {
+segmentEfforts.prototype.get = function (args) {
   var endpoint = 'segment_efforts/'
 
   // require segment id
@@ -12,7 +12,7 @@ segmentEfforts.prototype.get = function (args, done) {
   }
 
   endpoint += args.id
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 //= ==== segment_efforts endpoint =====
 

--- a/lib/segments.js
+++ b/lib/segments.js
@@ -5,7 +5,6 @@ var segments = function (client) {
 // Validation could be tightened up here by only allowing the properties to validate
 // for the single endpoint they are valid for.
 var _qsAllowedProps = [
-
   // pagination
   'page',
   'per_page',
@@ -35,69 +34,64 @@ var _updateAllowedProps = [
 ]
 
 //= ==== segments endpoint =====
-segments.prototype.get = function (args, done) {
+segments.prototype.get = function (args) {
   var endpoint = 'segments/'
   this.client.getPaginationQS(args)
 
   // require segment id
   if (typeof args.id === 'undefined') {
-    const err = { msg: 'args must include an segment id' }
-    return done(err)
+    throw new Error('args must include an segment id')
   }
 
   endpoint += args.id
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 
-segments.prototype.listStarred = function (args, done) {
+segments.prototype.listStarred = function (args) {
   var qs = this.client.getQS(_qsAllowedProps, args)
   var endpoint = 'segments/starred?' + qs
 
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 
-segments.prototype.starSegment = function (args, done) {
+segments.prototype.starSegment = function (args) {
   var endpoint = 'segments/'
   var form = this.client.getRequestBodyObj(_updateAllowedProps, args)
-  var err = null
 
   if (typeof args.id === 'undefined') {
-    err = { msg: 'args must include an segment id' }
-    return done(err)
+    throw new Error('args must include an segment id')
   }
 
   endpoint += args.id + '/starred'
   args.form = form
 
-  return this.client.putEndpoint(endpoint, args, done)
+  return this.client.putEndpoint(endpoint, args)
 }
 
-segments.prototype.listEfforts = function (args, done) {
-  return this._listHelper('all_efforts', args, done)
+segments.prototype.listEfforts = function (args) {
+  return this._listHelper('all_efforts', args)
 }
 
-segments.prototype.explore = function (args, done) {
+segments.prototype.explore = function (args) {
   var qs = this.client.getQS(_qsAllowedProps, args)
   var endpoint = 'segments/explore?' + qs
 
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 //= ==== segments endpoint =====
 
 //= ==== helpers =====
-segments.prototype._listHelper = function (listType, args, done) {
+segments.prototype._listHelper = function (listType, args) {
   var endpoint = 'segments/'
-  var err = null
   var qs = this.client.getQS(_qsAllowedProps, args)
 
   // require segment id
   if (typeof args.id === 'undefined') {
-    err = { msg: 'args must include a segment id' }
-    return done(err)
+    throw new Error('args must include a segment id')
   }
 
   endpoint += args.id + '/' + listType + '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 //= ==== helpers =====
 

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -8,29 +8,29 @@ var _qsAllowedProps = [
 ]
 
 //= ==== streams endpoint =====
-streams.prototype.activity = function (args, done) {
+streams.prototype.activity = function (args) {
   var endpoint = 'activities'
-  return this._typeHelper(endpoint, args, done)
+  return this._typeHelper(endpoint, args)
 }
 
-streams.prototype.effort = function (args, done) {
+streams.prototype.effort = function (args) {
   var endpoint = 'segment_efforts'
-  return this._typeHelper(endpoint, args, done)
+  return this._typeHelper(endpoint, args)
 }
 
-streams.prototype.segment = function (args, done) {
+streams.prototype.segment = function (args) {
   var endpoint = 'segments'
-  return this._typeHelper(endpoint, args, done)
+  return this._typeHelper(endpoint, args)
 }
 
-streams.prototype.route = function (args, done) {
+streams.prototype.route = function (args) {
   var endpoint = 'routes'
-  return this._typeHelper(endpoint, args, done)
+  return this._typeHelper(endpoint, args)
 }
 //= ==== streams endpoint =====
 
 //= ==== helpers =====
-streams.prototype._typeHelper = function (endpoint, args, done) {
+streams.prototype._typeHelper = function (endpoint, args) {
   var qs = this.client.getQS(_qsAllowedProps, args)
 
   // require id
@@ -43,7 +43,7 @@ streams.prototype._typeHelper = function (endpoint, args, done) {
   }
 
   endpoint += '/' + args.id + '/streams/' + args.types + '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+  return this.client.getEndpoint(endpoint, args)
 }
 //= ==== helpers =====
 

--- a/lib/uploads.js
+++ b/lib/uploads.js
@@ -11,12 +11,11 @@ var _allowedFormProps = [
   'data_type'
 ]
 
-uploads.prototype.post = function (args, done) {
-  var self = this
-
+uploads.prototype.post = function (args) {
   // various requirements
   if (
-    typeof args.file === 'undefined' || typeof args.data_type === 'undefined'
+    typeof args.file === 'undefined' ||
+    typeof args.data_type === 'undefined'
   ) {
     throw new Error('args must include both file and data_type')
   }
@@ -24,40 +23,48 @@ uploads.prototype.post = function (args, done) {
   // setup formData for request
   args.formData = {}
   for (var i = 0; i < _allowedFormProps.length; i++) {
-    if (args[_allowedFormProps[i]]) { args.formData[_allowedFormProps[i]] = args[_allowedFormProps[i]] }
+    if (args[_allowedFormProps[i]]) {
+      args.formData[_allowedFormProps[i]] = args[_allowedFormProps[i]]
+    }
   }
 
-  return this.client.postUpload(args, function (err, payload) {
-    // finish off this branch of the call and let the
-    // status checking bit happen after
-    done(err, payload)
-
-    if (!err && args.statusCallback) {
+  // Post the upload, returning a promise
+  return this.client.postUpload(args).then((payload) => {
+    // If the user provided a statusCallback, start checking periodically
+    if (!payload.err && args.statusCallback) {
       var checkArgs = {
         id: payload.id,
         access_token: args.access_token
       }
-      return self._check(checkArgs, args.statusCallback)
+      // Kick off the status checks in the background
+      this._check(checkArgs, args.statusCallback)
     }
+    return payload
   })
 }
 
-uploads.prototype._check = function (args, cb) {
-  var endpoint = 'uploads'
-  var self = this
+uploads.prototype._check = function (args, statusCallback) {
+  var endpoint = 'uploads/' + args.id
 
-  endpoint += '/' + args.id
-  return this.client.getEndpoint(endpoint, args, function (err, payload) {
-    if (!err) {
-      cb(err, payload)
-      if (!self._uploadIsDone(payload)) {
-        setTimeout(function () {
-          self._check(args, cb)
+  // Convert to a promise-based approach
+  return this.client.getEndpoint(endpoint, args).then((payload) => {
+    // Invoke the user's statusCallback with the latest status
+    statusCallback(null, payload)
+
+    // If not done, schedule another check
+    if (!this._uploadIsDone(payload)) {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          // Recursively call _check, chaining the promise
+          this._check(args, statusCallback).then(resolve).catch(reject)
         }, 1000)
-      }
-    } else {
-      cb(err)
+      })
     }
+    // If it's done, just resolve immediately with the final payload
+    return payload
+  }).catch((err) => {
+    statusCallback(err)
+    throw err
   })
 }
 
@@ -68,7 +75,6 @@ uploads.prototype._uploadIsDone = function (args) {
     case 'Your activity is still being processed.':
       isDone = false
       break
-
     default:
       isDone = true
   }


### PR DESCRIPTION
This PR removes all callback support across node-strava-v3, unifying the library under a promise-based API. 

Notably, the _check method in uploads is now a promise-based polling mechanism instead of a callback approach, while still preserving the user-facing statusCallback for progress updates. Because this is a breaking change, we will release a new major version.

Key Changes

* Removed done parameters from all endpoints (activities, athlete, clubs, segments, streams, etc.).
* Replaced return done(err) with throw new Error(...).
* Updated the uploads module so _check is promise-based (no more internal callbacks).
* Retained the optional statusCallback in uploads for users who want to monitor upload progress.

Impact
* Existing code that uses (args, done) style calls must switch to the new promise-based approach.
