### PR TITLE
Bugfix: Route XML files

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ type Callback = (error: any, payload: any) => void;
 
 interface BaseArgs {
   access_token?: string;
+  responseType?: string;
 }
 
 interface ApplicationBaseArgs {

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -16,7 +16,10 @@ HttpClient.prototype.getEndpoint = async function (endpoint, args) {
     args = {}
   }
 
-  var options = { url: endpoint }
+  var options = { 
+    url: endpoint,
+    responseType: args.responseType || 'json'
+   }
 
   if (args.access_token) {
     options.headers = { Authorization: 'Bearer ' + args.access_token }
@@ -37,7 +40,8 @@ HttpClient.prototype.putEndpoint = async function (endpoint, args) {
   const options = {
     url: endpoint,
     method: 'PUT',
-    body: qs
+    body: qs,
+    responseType: args.responseType || 'json'
   }
 
   if (args.access_token) {
@@ -59,7 +63,8 @@ HttpClient.prototype.postEndpoint = async function (endpoint, args) {
   var options = {
     url: endpoint,
     method: 'POST',
-    body: args.body
+    body: args.body,
+    responseType: args.responseType || 'json'
   }
 
   if (args.access_token) {
@@ -87,7 +92,8 @@ HttpClient.prototype.deleteEndpoint = async function (endpoint, args) {
   var options = {
     url: endpoint,
     method: 'DELETE',
-    body: qs
+    body: qs,
+    responseType: args.responseType || 'json'
   }
 
   if (args.access_token) {
@@ -105,7 +111,8 @@ HttpClient.prototype.postUpload = async function (args = {}) {
     formData: {
       ...args.formData,
       file: fs.createReadStream(args.file)
-    }
+    },
+    responseType: args.responseType || 'json'
   }
 
   if (args.access_token) {

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -16,10 +16,10 @@ HttpClient.prototype.getEndpoint = async function (endpoint, args) {
     args = {}
   }
 
-  var options = { 
+  var options = {
     url: endpoint,
     responseType: args.responseType || 'json'
-   }
+  }
 
   if (args.access_token) {
     options.headers = { Authorization: 'Bearer ' + args.access_token }
@@ -175,28 +175,34 @@ HttpClient.prototype._requestHelper = async function (options) {
 
   try {
     const response = await this.request(options)
-  
+
     // Update rate limits using headers from the successful response
     rateLimiting.updateRateLimits(response.headers)
-  
+
     // if the client auto-parsed JSON, response is already an object:
     if (typeof response === 'object' && !response.body) {
       return response
     }
-  
+
     // parse the raw JSON string with big-integer reviver for 16+ digit numbers
     return JSON.parse(response.body, (key, value) => {
-      if (typeof value === 'string' && /^\d{16,}$/.test(value)) {
-        return JSONbig.parse(value)
+      if (options.responseType == 'json') {
+        return JSON.parse(response, (key, value) => {
+          if (typeof value === 'string' && /^\d{16,}$/.test(value)) {
+            return JSONbig.parse(value)
+          }
+          return value
+        })
+      } else {
+        return response
       }
-      return value
     })
   } catch (e) {
     // If the error includes a response, update the rate limits using its headers
     if (e.response && e.response.headers) {
       rateLimiting.updateRateLimits(e.response.headers)
     }
-  
+
     // Re-throw the error to ensure it's handled elsewhere
     throw e
   }

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -184,19 +184,25 @@ HttpClient.prototype._requestHelper = async function (options) {
       return response
     }
 
-    // parse the raw JSON string with big-integer reviver for 16+ digit numbers
-    return JSON.parse(response.body, (key, value) => {
-      if (options.responseType == 'json') {
-        return JSON.parse(response, (key, value) => {
-          if (typeof value === 'string' && /^\d{16,}$/.test(value)) {
-            return JSONbig.parse(value)
-          }
-          return value
-        })
-      } else {
-        return response
-      }
-    })
+    if (typeof response === 'string') {
+      // parse the raw JSON string with big-integer reviver for 16+ digit numbers
+      return JSON.parse(response, (key, value) => {
+        if (options.responseType == 'json') {
+          return JSON.parse(response, (key, value) => {
+            if (typeof value === 'string' && /^\d{16,}$/.test(value)) {
+              return JSONbig.parse(value)
+            }
+            return value
+          })
+        } else {
+          return response
+        }
+      })
+    }
+
+    // response is not a string or object return it
+    return response
+
   } catch (e) {
     // If the error includes a response, update the rate limits using its headers
     if (e.response && e.response.headers) {

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -132,7 +132,7 @@ HttpClient.prototype.getPaginationQS = function (args) {
 
   return qs
 }
-//= ==== generic get query string =====
+//==== generic get query string =====
 HttpClient.prototype.getQS = function (allowedProps, args) {
   var qa = {}
   var qs
@@ -172,8 +172,18 @@ HttpClient.prototype._requestHelper = async function (options) {
     // Update rate limits using headers from the successful response
     rateLimiting.updateRateLimits(response.headers)
   
-    // Return the parsed response body
-    return JSONbig.parse(response.body)
+    // if the client auto-parsed JSON, response is already an object:
+    if (typeof response === 'object' && !response.body) {
+      return response
+    }
+  
+    // parse the raw JSON string with big-integer reviver for 16+ digit numbers
+    return JSON.parse(response.body, (key, value) => {
+      if (typeof value === 'string' && /^\d{16,}$/.test(value)) {
+        return JSONbig.parse(value)
+      }
+      return value
+    })
   } catch (e) {
     // If the error includes a response, update the rate limits using its headers
     if (e.response && e.response.headers) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -35,7 +35,10 @@ routes.prototype._getFileHelper = function (endpoint, args, done) {
   var qs = this.client.getQS(_qsAllowedProps, args)
 
   endpoint += args.id + `/export_${args.file_type}` + '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+
+  var requestArgs = Object.assign({}, args, { responseType: 'text' })
+
+  return this.client.getEndpoint(endpoint, requestArgs, done)
 }
 //= ==== helpers =====
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -20,7 +20,7 @@ routes.prototype.getFile = function (args, done) {
 
   _requireRouteId(args)
 
-  this._getFileHelper(endpoint, args, done)
+  return this._getFileHelper(endpoint, args, done)
 }
 //= ==== routes endpoint =====
 


### PR DESCRIPTION
Now correctly using the `responseType` argument and parsing where we want instead of all the time.
#164 