### PR TITLE
Remove request-promise/Bluebird references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Example error checking:
     // Catch a non-2xx response with the Promise API
     badClient.athlete.get({})
         .catch((e) => {
-            if (e instanceof StatusCodeError) {
+            if (e.name === 'StatusCodeError') {
                 // handle StatusCodeError
             }
         });

--- a/README.md
+++ b/README.md
@@ -209,8 +209,7 @@ Returns `null` if `X-Ratelimit-Limit` or `X-RateLimit-Usage` headers are not pro
 
 #### Global status
 
-In our promise API, only the response body "payload" value is returned as a
-[Bluebird promise](https://bluebirdjs.com/docs/api-reference.html). To track
+In our promise API, only the response body "payload" value is returned as a Promise. To track
 rate limiting we use a global counter accessible through `strava.rateLimiting`.
  The rate limiting status is updated with each request.
 
@@ -347,12 +346,17 @@ Example error checking:
 
     // Catch a non-2xx response with the Promise API
     badClient.athlete.get({})
-        .catch(StatusCodeError, function (e) {
+        .catch((e) => {
+            if (e instanceof StatusCodeError) {
+                // handle StatusCodeError
+            }
         });
 
-    badClient.athlete.get({}, function(err, payload) {
-      // err will be an instance of StatusCodeError or RequestError
-    });
+    // Or handle all errors
+    badClient.athlete.get({})
+        .catch((err) => {
+            console.error(err);
+        });
 ```
 
 The `StatusCodeError` object includes extra properties to help with debugging:
@@ -418,18 +422,6 @@ Using the provided `access_token` tests will access each endpoint individually:
 * (For all `GET` endpoints) checks to ensure the correct type has been returned from the Strava.
 * (For `PUT` in `athlete.update`) changes some athlete properties, then changes them back.
 * (For `POST/PUT/DELETE` in `activities.create/update/delete`) first creates an activity, runs some operations on it, then deletes it.
-
-## Debugging
-
-You can enable a debug mode for the underlying `request` module to see details
-about the raw HTTP requests and responses being sent back and forth from the
-Strava API.
-
-To enable this, set this in the environment before this module is loaded:
-
-  NODE\_DEBUG=request
-
-You can also set `process.env.NODE_DEBUG='request' in your script before this module is loaded.
 
 ## Resources
 


### PR DESCRIPTION
Fixes #170 

**Changes**

- Error Handling section: Updated example code to use native Promise error handling instead of Bluebird-style filtered `.catch()` syntax
- Rate limits section: Removed reference to "Bluebird promise" - now simply refers to "Promise"
- Debugging section: Removed outdated section that referenced the `request` module, which has been replaced by Axios

**Context**
After migrating from `request-promise` to Axios, the README still contained examples and references that assumed Bluebird promises were being used. This PR updates the documentation to reflect that the library now uses native JavaScript Promises.

The error handling examples now use standard `instanceof` checks instead of Bluebird's filtered catch syntax, which will work correctly with native Promises.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README updated to use consistent Promise-based error handling and remove the callback example.
  * Examples and wording changed to reflect new error object shapes and how specific errors are checked.
  * Clarified that the API returns a standard Promise resolving to the payload and described global rate-limiting via a counter.
  * Removed legacy debugging instructions tied to the previous request implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->