### PR TITLE
Update allowed form props for Uploads method

### DIFF
--- a/lib/uploads.js
+++ b/lib/uploads.js
@@ -3,12 +3,14 @@ var uploads = function (client) {
 }
 
 var _allowedFormProps = [
-  'activity_type',
+  'sport_type', // Overrides sport type detected from file, if left unspecified sport type detected from file will be used
+  'activity_type', // Deprecated: prefer using sport_type, will be ignored if sport_type is included.
   'name',
   'description',
-  'private',
   'trainer',
-  'data_type'
+  'commute',
+  'data_type',
+  'external_id'
 ]
 
 uploads.prototype.post = function (args, done) {

--- a/test/uploads.js
+++ b/test/uploads.js
@@ -10,6 +10,7 @@ describe.skip('uploads_test', function () {
       new Promise(function (resolve, reject) {
         strava.uploads.post({
           activity_type: 'run',
+          sport_type: 'Run',
           data_type: 'gpx',
           name: 'test activity',
           file: 'test/assets/gpx_sample.gpx',


### PR DESCRIPTION
- Updates allowed form properties to match those allowed by Strava API (see https://developers.strava.com/docs/reference/#api-Uploads-createUpload)
- `private` used to be allowed by Strava API but is no longer able to be used.
- New fields include:
  - `commute`
  - `external_id`
  - `sport_type`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Uploads now accept sport_type, commute, and external_id in form submissions.
* Chores
  * activity_type remains supported but is deprecated and ignored when sport_type is provided.
  * private is no longer accepted.
  * Validation and upload flow are unchanged: file and data_type remain required; behavior and error handling unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->