### PR TITLE
Fix callback issues on Athlete and Uploads API

### DIFF
--- a/lib/athlete.js
+++ b/lib/athlete.js
@@ -18,39 +18,37 @@ var _updateAllowedProps = [
 ]
 
 //= ==== athlete endpoint =====
-athlete.prototype.get = function (args, done) {
+athlete.prototype.get = async function (args) {
   var endpoint = 'athlete'
-  return this.client.getEndpoint(endpoint, args, done)
+  return await this.client.getEndpoint(endpoint, args)
 }
-athlete.prototype.listActivities = function (args, done) {
-  return this._listHelper('activities', args, done)
+athlete.prototype.listActivities = async function (args) {
+  return await this._listHelper('activities', args)
 }
-athlete.prototype.listClubs = function (args, done) {
-  return this._listHelper('clubs', args, done)
+athlete.prototype.listClubs = async function (args) {
+  return await this._listHelper('clubs', args)
 }
-athlete.prototype.listRoutes = function (args, done) {
-  return this._listHelper('routes', args, done)
+athlete.prototype.listRoutes = async function (args) {
+  return await this._listHelper('routes', args)
 }
-athlete.prototype.listZones = function (args, done) {
-  return this._listHelper('zones', args, done)
+athlete.prototype.listZones = async function (args) {
+  return await this._listHelper('zones', args)
 }
 
-athlete.prototype.update = function (args, done) {
+athlete.prototype.update = async function (args) {
   var endpoint = 'athlete'
-  var form = this.client.getRequestBodyObj(_updateAllowedProps, args)
-
-  args.form = form
-  return this.client.putEndpoint(endpoint, args, done)
+  args.body = this.client.getRequestBodyObj(_updateAllowedProps, args)
+  return await this.client.putEndpoint(endpoint, args)
 }
 //= ==== athlete.prototype endpoint =====
 
 //= ==== helpers =====
-athlete.prototype._listHelper = function (listType, args, done) {
+athlete.prototype._listHelper = async function (listType, args) {
   var endpoint = 'athlete/'
   var qs = this.client.getQS(_qsAllowedProps, args)
 
   endpoint += listType + '?' + qs
-  return this.client.getEndpoint(endpoint, args, done)
+  return await this.client.getEndpoint(endpoint, args)
 }
 //= ==== helpers =====
 

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -112,19 +112,17 @@ HttpClient.prototype.postUpload = async function (args = {}) {
       ...args.formData,
       file: fs.createReadStream(args.file)
     },
-    responseType: args.responseType || 'formdata',
+    responseType: 'formdata',
     headers: {
       'Content-Type': 'multipart/form-data'
     }
   }
 
   if (args.access_token) {
-    options.headers = { Authorization: 'Bearer ' + args.access_token }
+    options.headers.Authorization = 'Bearer ' + args.access_token
   }
 
-  const responseString = await this._requestHelper(options)
-
-  return JSON.parse(responseString)
+  return await this._requestHelper(options)
 }
 
 //= ==== get pagination query string =====
@@ -192,7 +190,7 @@ HttpClient.prototype._requestHelper = async function (options) {
     if (typeof response === 'string') {
       // parse the raw JSON string with big-integer reviver for 16+ digit numbers
       return JSON.parse(response, (key, value) => {
-        if (options.responseType === 'json') {
+        if (options.responseType === 'json' || options.responseType === 'formdata') {
           return JSON.parse(response, (key, value) => {
             if (typeof value === 'string' && /^\d{16,}$/.test(value)) {
               return JSONbig.parse(value)

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -108,18 +108,23 @@ HttpClient.prototype.postUpload = async function (args = {}) {
   var options = {
     url: 'uploads',
     method: 'POST',
-    formData: {
+    body: {
       ...args.formData,
       file: fs.createReadStream(args.file)
     },
-    responseType: args.responseType || 'json'
+    responseType: args.responseType || 'formdata',
+    headers: {
+      'Content-Type': 'multipart/form-data'
+    }
   }
 
   if (args.access_token) {
     options.headers = { Authorization: 'Bearer ' + args.access_token }
   }
 
-  return this.request.post(options)
+  const responseString = await this._requestHelper(options)
+
+  return JSON.parse(responseString)
 }
 
 //= ==== get pagination query string =====

--- a/lib/uploads.js
+++ b/lib/uploads.js
@@ -35,7 +35,7 @@ uploads.prototype.post = async function (args) {
 
   // if no statusCallback, just return after posting upload
   if (typeof args.statusCallback === 'undefined') {
-    return
+    return response
   }
 
   // otherwise, kick off the status checking loop

--- a/lib/uploads.js
+++ b/lib/uploads.js
@@ -1,3 +1,5 @@
+const { setTimeout } = require('timers/promises');
+
 var uploads = function (client) {
   this.client = client
 }
@@ -13,7 +15,7 @@ var _allowedFormProps = [
   'external_id'
 ]
 
-uploads.prototype.post = function (args, done) {
+uploads.prototype.post = async function (args) {
   var self = this
 
   // various requirements
@@ -29,38 +31,40 @@ uploads.prototype.post = function (args, done) {
     if (args[_allowedFormProps[i]]) { args.formData[_allowedFormProps[i]] = args[_allowedFormProps[i]] }
   }
 
-  return this.client.postUpload(args, function (err, payload) {
-    // finish off this branch of the call and let the
-    // status checking bit happen after
-    done(err, payload)
+  const response = await this.client.postUpload(args)
 
-    if (!err && args.statusCallback) {
-      var checkArgs = {
-        id: payload.id,
-        access_token: args.access_token
-      }
-      return self._check(checkArgs, args.statusCallback)
-    }
-  })
+  // if no statusCallback, just return after posting upload
+  if (typeof args.statusCallback === 'undefined') {
+    return
+  }
+
+  // otherwise, kick off the status checking loop
+  // and return the result of that
+  // the callback will be called on each status check
+  var checkArgs = {
+    id: response.id,
+    access_token: args.access_token
+  }
+  return await self._check(checkArgs, args.statusCallback)
+
 }
 
-uploads.prototype._check = function (args, cb) {
+uploads.prototype._check = async function (args, cb) {
   var endpoint = 'uploads'
   var self = this
 
   endpoint += '/' + args.id
-  return this.client.getEndpoint(endpoint, args, function (err, payload) {
-    if (!err) {
-      cb(err, payload)
-      if (!self._uploadIsDone(payload)) {
-        setTimeout(function () {
-          self._check(args, cb)
-        }, 1000)
-      }
-    } else {
-      cb(err)
+
+  try {
+    const response = await this.client.getEndpoint(endpoint, args)
+
+    cb(response.error, response)
+    if (!self._uploadIsDone(response)) {
+      await setTimeout(1000, await self._check(args, cb))
     }
-  })
+  } catch (err) {
+    cb(err)
+  }
 }
 
 uploads.prototype._uploadIsDone = function (args) {

--- a/lib/uploads.js
+++ b/lib/uploads.js
@@ -60,7 +60,8 @@ uploads.prototype._check = async function (args, cb) {
 
     cb(response.error, response)
     if (!self._uploadIsDone(response)) {
-      await setTimeout(1000, await self._check(args, cb))
+      await setTimeout(1000)
+      return await self._check(args, cb)
     }
   } catch (err) {
     cb(err)

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -16,7 +16,7 @@ testsHelper.getSampleActivity = function (done) {
     // If we find an activity with an achievement, there's a better chance
     // that it contains a segment.
     // This is necessary for getSampleSegment, which uses this function.
-    function hasAchievement (activity) { return activity.achievement_count > 1 }
+    function hasAchievement(activity) { return activity.achievement_count > 1 }
 
     var withSegment = payload.filter(hasAchievement)[0]
 
@@ -46,22 +46,19 @@ testsHelper.getSampleRoute = function (done) {
   })
 }
 
-testsHelper.getSampleGear = function (done) {
-  this.getSampleAthlete(function (err, payload) {
-    if (err) { return done(err) }
+testsHelper.getSampleGear = async function () {
+  const payload = await this.getSampleAthlete()
 
-    var gear
+  var gear
 
-    if (payload.bikes && payload.bikes.length) {
-      gear = payload.bikes[0]
-    } else if (payload.shoes) {
-      gear = payload.shoes[0]
-    } else {
-      return done(new Error('Must post at least one bike or shoes to Strava to test with'))
-    }
+  if (payload.bikes && payload.bikes.length) {
+    gear = payload.bikes[0]
+  } else if (payload.shoes) {
+    gear = payload.shoes[0]
+  } else {
+    return done(new Error('Must post at least one bike or shoes to Strava to test with'))
+  }
 
-    done(err, gear)
-  })
 }
 
 testsHelper.getSampleSegmentEffort = function (done) {

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -56,9 +56,10 @@ testsHelper.getSampleGear = async function () {
   } else if (payload.shoes) {
     gear = payload.shoes[0]
   } else {
-    return done(new Error('Must post at least one bike or shoes to Strava to test with'))
+    throw new Error('Must post at least one bike or shoes to Strava to test with')
   }
 
+  return gear
 }
 
 testsHelper.getSampleSegmentEffort = function (done) {

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -3,8 +3,8 @@ var strava = require('../')
 
 var testsHelper = {}
 
-testsHelper.getSampleAthlete = function (done) {
-  strava.athlete.get({}, done)
+testsHelper.getSampleAthlete = async function () {
+  return await strava.athlete.get({})
 }
 
 testsHelper.getSampleActivity = function (done) {

--- a/test/assets/gpx_sample.gpx
+++ b/test/assets/gpx_sample.gpx
@@ -6,1053 +6,1053 @@
     http://www.garmin.com/xmlschemas/TrackPointExtension/v1
     http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata>
-    <time>2015-11-25T23:45:55.000Z</time>
+    <time>PLACEHOLDER</time>
   </metadata>
   <trk>
     <trkseg>
       <trkpt lon="-73.5408325195312500" lat="41.0659866333007812">
         <ele>21.0</ele>
-        <time>2015-11-25T23:45:55.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5412063598632812" lat="41.0658607482910156">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:46:02.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5413436889648438" lat="41.0658340454101562">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:46:04.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5414505004882812" lat="41.0658187866210938">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:46:07.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5414505004882812" lat="41.0658187866210938">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:46:08.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5414505004882812" lat="41.0658187866210938">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:46:10.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5414505004882812" lat="41.0658187866210938">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:46:15.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5414505004882812" lat="41.0658187866210938">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:46:15.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5419540405273438" lat="41.0660858154296875">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:46:22.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5419540405273438" lat="41.0660858154296875">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:46:22.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5421066284179688" lat="41.0662727355957031">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:46:26.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5421066284179688" lat="41.0662727355957031">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:46:29.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5421066284179688" lat="41.0662727355957031">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:46:30.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5422210693359375" lat="41.0665283203125000">
         <ele>-24.0</ele>
-        <time>2015-11-25T23:46:34.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5422210693359375" lat="41.0665283203125000">
         <ele>-24.0</ele>
-        <time>2015-11-25T23:46:37.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5423355102539062" lat="41.0666809082031250">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:46:38.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:46:45.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:46:45.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:46:46.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:46:48.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:46:50.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:46:52.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:46:54.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:46:56.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:46:58.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:47:04.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424575805664062" lat="41.0667991638183594">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:47:06.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5431900024414062" lat="41.0675354003906250">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:47:10.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5432891845703125" lat="41.0676269531250000">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:47:14.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5432891845703125" lat="41.0676269531250000">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:47:16.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5432891845703125" lat="41.0676269531250000">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:47:18.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5434341430664062" lat="41.0677337646484375">
         <ele>-29.0</ele>
-        <time>2015-11-25T23:47:24.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5435333251953125" lat="41.0678062438964844">
         <ele>-27.0</ele>
-        <time>2015-11-25T23:47:26.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5435333251953125" lat="41.0678062438964844">
         <ele>-27.0</ele>
-        <time>2015-11-25T23:47:28.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5435333251953125" lat="41.0678062438964844">
         <ele>-27.0</ele>
-        <time>2015-11-25T23:47:30.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5435333251953125" lat="41.0678062438964844">
         <ele>-27.0</ele>
-        <time>2015-11-25T23:47:32.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5435333251953125" lat="41.0678062438964844">
         <ele>-27.0</ele>
-        <time>2015-11-25T23:47:38.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5438079833984375" lat="41.0679740905761719">
         <ele>-27.0</ele>
-        <time>2015-11-25T23:47:42.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5439605712890625" lat="41.0680770874023438">
         <ele>-29.0</ele>
-        <time>2015-11-25T23:47:44.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440597534179688" lat="41.0681457519531250">
         <ele>-27.0</ele>
-        <time>2015-11-25T23:47:46.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441284179687500" lat="41.0681991577148438">
         <ele>-25.0</ele>
-        <time>2015-11-25T23:47:48.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441894531250000" lat="41.0682563781738281">
         <ele>-24.0</ele>
-        <time>2015-11-25T23:47:50.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441894531250000" lat="41.0682563781738281">
         <ele>-24.0</ele>
-        <time>2015-11-25T23:47:52.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441894531250000" lat="41.0682563781738281">
         <ele>-24.0</ele>
-        <time>2015-11-25T23:47:54.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441894531250000" lat="41.0682563781738281">
         <ele>-24.0</ele>
-        <time>2015-11-25T23:47:56.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441894531250000" lat="41.0682563781738281">
         <ele>-24.0</ele>
-        <time>2015-11-25T23:47:58.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5445251464843750" lat="41.0685577392578125">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:48:02.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5446166992187500" lat="41.0686531066894531">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:06.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5446166992187500" lat="41.0686531066894531">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:08.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5446166992187500" lat="41.0686531066894531">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:10.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5447387695312500" lat="41.0687980651855469">
         <ele>-17.0</ele>
-        <time>2015-11-25T23:48:12.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5448150634765625" lat="41.0688896179199219">
         <ele>-16.0</ele>
-        <time>2015-11-25T23:48:16.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5448150634765625" lat="41.0688896179199219">
         <ele>-16.0</ele>
-        <time>2015-11-25T23:48:18.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5448989868164062" lat="41.0690116882324219">
         <ele>-16.0</ele>
-        <time>2015-11-25T23:48:20.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5449905395507812" lat="41.0691299438476562">
         <ele>-16.0</ele>
-        <time>2015-11-25T23:48:24.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:28.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:30.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:32.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:34.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:36.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:38.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:42.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:44.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:46.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450744628906250" lat="41.0692367553710938">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:48:48.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5456848144531250" lat="41.0697746276855469">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:48:54.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5456848144531250" lat="41.0697746276855469">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:48:56.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5456848144531250" lat="41.0697746276855469">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:48:58.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5456848144531250" lat="41.0697746276855469">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:49:00.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5456848144531250" lat="41.0697746276855469">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:49:02.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5459365844726562" lat="41.0700149536132812">
         <ele>-17.0</ele>
-        <time>2015-11-25T23:49:06.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5460281372070312" lat="41.0700607299804688">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:49:12.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5460815429687500" lat="41.0701065063476562">
         <ele>-17.0</ele>
-        <time>2015-11-25T23:49:14.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5461502075195312" lat="41.0701751708984375">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:49:18.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5462112426757812" lat="41.0702285766601562">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:49:20.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5462112426757812" lat="41.0702285766601562">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:49:22.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5463104248046875" lat="41.0702819824218750">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:49:24.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5463104248046875" lat="41.0702819824218750">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:49:26.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5463104248046875" lat="41.0702819824218750">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:49:28.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5463104248046875" lat="41.0702819824218750">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:49:30.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5463104248046875" lat="41.0702819824218750">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:49:32.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5465469360351562" lat="41.0704727172851562">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:49:40.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5466995239257812" lat="41.0705833435058594">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:49:42.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5468063354492188" lat="41.0706558227539062">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:49:44.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5468978881835938" lat="41.0707092285156250">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:49:46.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5469818115234375" lat="41.0707511901855469">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:49:48.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5469818115234375" lat="41.0707511901855469">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:49:50.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5469818115234375" lat="41.0707511901855469">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:49:52.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5469818115234375" lat="41.0707511901855469">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:49:54.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5469818115234375" lat="41.0707511901855469">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:49:56.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5469818115234375" lat="41.0707511901855469">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:49:58.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5474853515625000" lat="41.0710029602050781">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:02.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5474853515625000" lat="41.0710029602050781">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:06.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5474853515625000" lat="41.0710029602050781">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:08.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5477294921875000" lat="41.0709686279296875">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:50:12.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5477294921875000" lat="41.0709686279296875">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:50:16.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5479049682617188" lat="41.0709991455078125">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:18.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5479049682617188" lat="41.0709991455078125">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:20.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5479049682617188" lat="41.0709991455078125">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:24.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5479049682617188" lat="41.0709991455078125">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:26.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5479049682617188" lat="41.0709991455078125">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:28.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5479049682617188" lat="41.0709991455078125">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:30.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5479049682617188" lat="41.0709991455078125">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:50:32.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5484008789062500" lat="41.0712394714355469">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:50:36.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5485610961914062" lat="41.0713081359863281">
         <ele>-6.0</ele>
-        <time>2015-11-25T23:50:42.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5485610961914062" lat="41.0713081359863281">
         <ele>-6.0</ele>
-        <time>2015-11-25T23:50:44.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5487060546875000" lat="41.0714149475097656">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:50:48.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5487060546875000" lat="41.0714149475097656">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:50:50.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5487060546875000" lat="41.0714149475097656">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:50:52.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5489578247070312" lat="41.0714874267578125">
         <ele>-6.0</ele>
-        <time>2015-11-25T23:50:54.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5490875244140625" lat="41.0714454650878906">
         <ele>-3.0</ele>
-        <time>2015-11-25T23:50:58.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5491409301757812" lat="41.0713310241699219">
         <ele>-3.0</ele>
-        <time>2015-11-25T23:51:02.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5491714477539062" lat="41.0712165832519531">
         <ele>-4.0</ele>
-        <time>2015-11-25T23:51:06.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5491714477539062" lat="41.0712165832519531">
         <ele>-4.0</ele>
-        <time>2015-11-25T23:51:08.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5491714477539062" lat="41.0712165832519531">
         <ele>-4.0</ele>
-        <time>2015-11-25T23:51:10.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5491867065429688" lat="41.0711097717285156">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:51:14.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492095947265625" lat="41.0710296630859375">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:51:16.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492172241210938" lat="41.0709648132324219">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:51:18.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492248535156250" lat="41.0709190368652344">
         <ele>-6.0</ele>
-        <time>2015-11-25T23:51:20.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492248535156250" lat="41.0709190368652344">
         <ele>-6.0</ele>
-        <time>2015-11-25T23:51:22.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492248535156250" lat="41.0709190368652344">
         <ele>-6.0</ele>
-        <time>2015-11-25T23:51:24.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492324829101562" lat="41.0707969665527344">
         <ele>-6.0</ele>
-        <time>2015-11-25T23:51:26.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492477416992188" lat="41.0706977844238281">
         <ele>-4.0</ele>
-        <time>2015-11-25T23:51:28.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492630004882812" lat="41.0706176757812500">
         <ele>-3.0</ele>
-        <time>2015-11-25T23:51:30.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492782592773438" lat="41.0705528259277344">
         <ele>-2.0</ele>
-        <time>2015-11-25T23:51:32.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492782592773438" lat="41.0705528259277344">
         <ele>-2.0</ele>
-        <time>2015-11-25T23:51:34.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492782592773438" lat="41.0705528259277344">
         <ele>-2.0</ele>
-        <time>2015-11-25T23:51:36.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492782592773438" lat="41.0705528259277344">
         <ele>-2.0</ele>
-        <time>2015-11-25T23:51:38.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492782592773438" lat="41.0705528259277344">
         <ele>-2.0</ele>
-        <time>2015-11-25T23:51:44.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492782592773438" lat="41.0705528259277344">
         <ele>-2.0</ele>
-        <time>2015-11-25T23:51:46.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492782592773438" lat="41.0705528259277344">
         <ele>-2.0</ele>
-        <time>2015-11-25T23:51:48.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492706298828125" lat="41.0702285766601562">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:51:52.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492477416992188" lat="41.0700454711914062">
         <ele>-9.0</ele>
-        <time>2015-11-25T23:51:54.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5492095947265625" lat="41.0699272155761719">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:51:56.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5491638183593750" lat="41.0698471069335938">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:51:58.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5491180419921875" lat="41.0697822570800781">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:52:00.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5490570068359375" lat="41.0696449279785156">
         <ele>-12.0</ele>
-        <time>2015-11-25T23:52:02.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5489807128906250" lat="41.0695304870605469">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:52:06.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5489807128906250" lat="41.0695304870605469">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:52:08.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5489807128906250" lat="41.0695304870605469">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:52:10.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5489807128906250" lat="41.0695304870605469">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:52:12.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5489807128906250" lat="41.0695304870605469">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:52:14.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5489807128906250" lat="41.0695304870605469">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:52:18.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5489807128906250" lat="41.0695304870605469">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:52:20.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5486679077148438" lat="41.0691070556640625">
         <ele>-12.0</ele>
-        <time>2015-11-25T23:52:24.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5486679077148438" lat="41.0691070556640625">
         <ele>-12.0</ele>
-        <time>2015-11-25T23:52:26.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5485382080078125" lat="41.0689544677734375">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:52:28.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5484466552734375" lat="41.0688362121582031">
         <ele>-12.0</ele>
-        <time>2015-11-25T23:52:33.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5484466552734375" lat="41.0688362121582031">
         <ele>-12.0</ele>
-        <time>2015-11-25T23:52:35.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5484466552734375" lat="41.0688362121582031">
         <ele>-12.0</ele>
-        <time>2015-11-25T23:52:37.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5484466552734375" lat="41.0688362121582031">
         <ele>-12.0</ele>
-        <time>2015-11-25T23:52:39.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5481491088867188" lat="41.0685958862304688">
         <ele>-12.0</ele>
-        <time>2015-11-25T23:52:45.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5480728149414062" lat="41.0685043334960938">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:52:49.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5480728149414062" lat="41.0685043334960938">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:52:51.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5480728149414062" lat="41.0685043334960938">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:52:53.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5480728149414062" lat="41.0685043334960938">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:52:55.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5478973388671875" lat="41.0683746337890625">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:52:57.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5478973388671875" lat="41.0683746337890625">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:52:59.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5477752685546875" lat="41.0682830810546875">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:53:01.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5477752685546875" lat="41.0682830810546875">
         <ele>-10.0</ele>
-        <time>2015-11-25T23:53:03.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5476379394531250" lat="41.0681571960449219">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:53:07.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5476379394531250" lat="41.0681571960449219">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:53:11.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5474395751953125" lat="41.0680580139160156">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:53:13.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5474395751953125" lat="41.0680580139160156">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:53:15.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5474395751953125" lat="41.0680580139160156">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:53:17.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5471801757812500" lat="41.0679321289062500">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:53:21.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5471801757812500" lat="41.0679321289062500">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:53:25.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5471801757812500" lat="41.0679321289062500">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:53:27.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5471801757812500" lat="41.0679321289062500">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:53:29.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5471801757812500" lat="41.0679321289062500">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:53:31.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5471801757812500" lat="41.0679321289062500">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:53:33.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5469284057617188" lat="41.0678291320800781">
         <ele>-12.0</ele>
-        <time>2015-11-25T23:53:39.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5467758178710938" lat="41.0677642822265625">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:53:41.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5466613769531250" lat="41.0677185058593750">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:53:43.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5465850830078125" lat="41.0676651000976562">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:53:45.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5465850830078125" lat="41.0676651000976562">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:53:47.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5465850830078125" lat="41.0676651000976562">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:53:49.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5465850830078125" lat="41.0676651000976562">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:53:51.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5464172363281250" lat="41.0675430297851562">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:53:55.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5463027954101562" lat="41.0674552917480469">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:53:57.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5463027954101562" lat="41.0674552917480469">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:53:59.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5461883544921875" lat="41.0673675537109375">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:54:01.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5461044311523438" lat="41.0673103332519531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:03.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5461044311523438" lat="41.0673103332519531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:05.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5461044311523438" lat="41.0673103332519531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:07.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5461044311523438" lat="41.0673103332519531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:13.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5461044311523438" lat="41.0673103332519531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:15.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5458755493164062" lat="41.0671691894531250">
         <ele>-9.0</ele>
-        <time>2015-11-25T23:54:17.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5457229614257812" lat="41.0670852661132812">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:54:19.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5456314086914062" lat="41.0670204162597656">
         <ele>-7.0</ele>
-        <time>2015-11-25T23:54:21.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5455780029296875" lat="41.0669708251953125">
         <ele>-8.0</ele>
-        <time>2015-11-25T23:54:23.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5455780029296875" lat="41.0669708251953125">
         <ele>-8.0</ele>
-        <time>2015-11-25T23:54:25.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5455780029296875" lat="41.0669708251953125">
         <ele>-8.0</ele>
-        <time>2015-11-25T23:54:27.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5454330444335938" lat="41.0668678283691406">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:54:31.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5453262329101562" lat="41.0667953491210938">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:33.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5452194213867188" lat="41.0667495727539062">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:54:35.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5451660156250000" lat="41.0666923522949219">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:54:37.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5451660156250000" lat="41.0666923522949219">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:54:39.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5451660156250000" lat="41.0666923522949219">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:54:41.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450668334960938" lat="41.0666389465332031">
         <ele>-17.0</ele>
-        <time>2015-11-25T23:54:46.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5450057983398438" lat="41.0665702819824219">
         <ele>-17.0</ele>
-        <time>2015-11-25T23:54:48.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5449600219726562" lat="41.0665092468261719">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:50.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5449142456054688" lat="41.0664558410644531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:52.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5449142456054688" lat="41.0664558410644531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:54.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5449142456054688" lat="41.0664558410644531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:54:56.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5449142456054688" lat="41.0664558410644531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:55:00.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5449142456054688" lat="41.0664558410644531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:55:02.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5449142456054688" lat="41.0664558410644531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:55:04.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5449142456054688" lat="41.0664558410644531">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:55:06.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5446548461914062" lat="41.0662231445312500">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:55:12.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5445022583007812" lat="41.0660858154296875">
         <ele>-21.0</ele>
-        <time>2015-11-25T23:55:14.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5444107055664062" lat="41.0659980773925781">
         <ele>-20.0</ele>
-        <time>2015-11-25T23:55:16.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5443496704101562" lat="41.0659255981445312">
         <ele>-19.0</ele>
-        <time>2015-11-25T23:55:18.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5442810058593750" lat="41.0658531188964844">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:55:20.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441741943359375" lat="41.0657348632812500">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:55:22.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441741943359375" lat="41.0657348632812500">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:55:24.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441741943359375" lat="41.0657348632812500">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:55:26.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5441741943359375" lat="41.0657348632812500">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:55:28.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:55:32.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:55:34.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:55:36.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:55:38.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:55:40.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:55:46.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:55:48.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:56:02.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:56:04.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:56:06.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5440216064453125" lat="41.0654678344726562">
         <ele>-22.0</ele>
-        <time>2015-11-25T23:56:08.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5435562133789062" lat="41.0652923583984375">
         <ele>-18.0</ele>
-        <time>2015-11-25T23:56:10.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5433959960937500" lat="41.0653533935546875">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:56:14.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5433959960937500" lat="41.0653533935546875">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:56:16.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5432662963867188" lat="41.0653686523437500">
         <ele>-17.0</ele>
-        <time>2015-11-25T23:56:18.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5431671142578125" lat="41.0654029846191406">
         <ele>-17.0</ele>
-        <time>2015-11-25T23:56:20.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5430831909179688" lat="41.0654373168945312">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:56:22.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5430831909179688" lat="41.0654373168945312">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:56:24.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5429382324218750" lat="41.0654907226562500">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:56:26.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5429382324218750" lat="41.0654907226562500">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:56:28.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5429382324218750" lat="41.0654907226562500">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:56:30.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5429382324218750" lat="41.0654907226562500">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:56:32.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5429382324218750" lat="41.0654907226562500">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:56:34.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5429382324218750" lat="41.0654907226562500">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:56:36.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5427017211914062" lat="41.0655784606933594">
         <ele>-11.0</ele>
-        <time>2015-11-25T23:56:38.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5425415039062500" lat="41.0656318664550781">
         <ele>-13.0</ele>
-        <time>2015-11-25T23:56:40.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5424270629882812" lat="41.0656661987304688">
         <ele>-14.0</ele>
-        <time>2015-11-25T23:56:42.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5423355102539062" lat="41.0657119750976562">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:56:44.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5422439575195312" lat="41.0657386779785156">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:56:47.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5420837402343750" lat="41.0657920837402344">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:56:49.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5420837402343750" lat="41.0657920837402344">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:56:51.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5420837402343750" lat="41.0657920837402344">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:56:53.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5420837402343750" lat="41.0657920837402344">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:56:55.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5420837402343750" lat="41.0657920837402344">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:56:57.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5420837402343750" lat="41.0657920837402344">
         <ele>-23.0</ele>
-        <time>2015-11-25T23:56:59.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5416793823242188" lat="41.0657997131347656">
         <ele>-17.0</ele>
-        <time>2015-11-25T23:57:28.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5415420532226562" lat="41.0658416748046875">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:57:31.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5415420532226562" lat="41.0658416748046875">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:57:33.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5415420532226562" lat="41.0658416748046875">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:57:35.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5415420532226562" lat="41.0658416748046875">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:57:37.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5415420532226562" lat="41.0658416748046875">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:57:39.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5415420532226562" lat="41.0658416748046875">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:57:43.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
       <trkpt lon="-73.5415420532226562" lat="41.0658416748046875">
         <ele>-15.0</ele>
-        <time>2015-11-25T23:57:43.000Z</time>
+        <time>PLACEHOLDER</time>
       </trkpt>
     </trkseg>
   </trk>

--- a/test/athlete.js
+++ b/test/athlete.js
@@ -4,109 +4,61 @@ const testHelper = require('./_helper')
 
 describe('athlete_test', function () {
   describe('#get()', function () {
-    it('should return detailed athlete information about athlete associated to access_token (level 3)', function (done) {
-      strava.athlete.get({}, function (err, payload) {
-        if (!err) {
-          (payload.resource_state).should.be.exactly(3)
-        } else {
-          console.log(err)
-        }
-
-        done()
-      })
+    it('should return detailed athlete information about athlete associated to access_token (level 3)', async () => {
+      const response = await strava.athlete.get({})
+      response.resource_state.should.be.exactly(3)
     })
   })
 
   describe('#listActivities()', function () {
-    it('should return information about activities associated to athlete with access_token', function (done) {
+    it('should return information about activities associated to athlete with access_token', async () => {
       var nowSeconds = Math.floor(Date.now() / 1000)
-      strava.athlete.listActivities({
+      const response = await strava.athlete.listActivities({
         after: nowSeconds + 3600,
         before: nowSeconds + 3600
-      }, function (err, payload) {
-        if (!err) {
-          // console.log(payload);
-          payload.should.be.instanceof(Array)
-        } else {
-          console.log(err)
-        }
-
-        done()
       })
+      response.should.be.instanceof(Array)
     })
   })
 
   describe('#listClubs()', function () {
-    it('should return information about clubs associated to athlete with access_token', function (done) {
-      strava.athlete.listClubs({}, function (err, payload) {
-        if (!err) {
-          payload.should.be.instanceof(Array)
-        } else {
-          console.log(err)
-        }
-
-        done()
-      })
+    it('should return information about clubs associated to athlete with access_token', async () => {
+      const response = await strava.athlete.listClubs({})
+      response.should.be.instanceof(Array)
     })
   })
 
   describe('#listRoutes()', function () {
-    it('should return information about routes associated to athlete with access_token', function (done) {
-      strava.athlete.listRoutes({}, function (err, payload) {
-        if (!err) {
-          payload.should.be.instanceof(Array)
-        } else {
-          console.log(err)
-        }
-
-        done()
-      })
+    it('should return information about routes associated to athlete with access_token', async () => {
+      const response = await strava.athlete.listRoutes({})
+      response.should.be.instanceof(Array)
     })
   })
 
   describe('#listZones()', function () {
-    it('should return information about heart-rate zones associated to athlete with access_token', function (done) {
-      strava.athlete.listZones({}, function (err, payload) {
-        if (!err) {
-          payload.should.be.instanceof(Object)
-        } else {
-          console.log(err)
-        }
-
-        done()
-      })
+    it('should return information about heart-rate zones associated to athlete with access_token', async () => {
+      const response = await strava.athlete.listZones({})
+      response.should.be.instanceof(Object)
     })
   })
 
   describe('#update()', function () {
     // grab the athlete so we can revert changes
     var _athletePreEdit
-    before(function (done) {
-      testHelper.getSampleAthlete(function (err, payload) {
-        should(err).be.null()
-        _athletePreEdit = payload
-        done()
-      })
+    before(async () => {
+      _athletePreEdit = await testHelper.getSampleAthlete()
     })
 
-    it('should update the weight of the current athlete and revert to original', function (done) {
+    it('should update the weight of the current athlete and revert to original', async () => {
       var weight = 149
 
-      strava.athlete.update({ weight }, function (err, payload) {
-        if (!err) {
-          should(payload.weight).equal(weight)
+      const response = await strava.athlete.update({ weight })
+      should(response.weight).equal(weight)
 
-          // great! we've proven our point, let's reset the athlete data
-          strava.athlete.update({ city: _athletePreEdit.city }, function (err, payload) {
-            should(err).be.null()
-            should(payload.city).equal(_athletePreEdit.city)
-            done()
-          })
-        } else {
-          console.log(err)
-          done()
-        }
-      })
+      // great! we've proven our point, let's reset the athlete data
+      const updateResponse = await strava.athlete.update({ city: _athletePreEdit.city, weight: _athletePreEdit.weight })
+      should(updateResponse.city).equal(_athletePreEdit.city)
+      should(updateResponse.weight).equal(_athletePreEdit.weight)
     })
   })
 })

--- a/test/athletes.js
+++ b/test/athletes.js
@@ -6,12 +6,8 @@ var _sampleAthlete
 
 describe('athletes', function () {
   // get the athlete so we have access to an id for testing
-  before(function (done) {
-    testHelper.getSampleAthlete(function (err, payload) {
-      should(err).be.null()
-      _sampleAthlete = payload
-      done()
-    })
+  before(async () => {
+    _sampleAthlete = await testHelper.getSampleAthlete()
   })
 
   describe('#get()', function () {

--- a/test/rateLimiting.js
+++ b/test/rateLimiting.js
@@ -77,24 +77,4 @@ describe('rateLimiting_test', function () {
       rateLimiting.exceeded().should.be.be.false()
     })
   })
-
-  describe('legacy callback limits', function () {
-    var limits
-    before(function (done) {
-      testHelper.getSampleAthlete(function (err, payload, gotLimits) {
-        if (err) { return done(err) }
-
-        limits = gotLimits || null
-        done()
-      })
-    })
-
-    it('should parse and return limits', function () {
-      limits.should.be.a.Object()
-      limits.shortTermUsage.should.be.a.Number()
-      limits.shortTermLimit.should.be.above(0).and.be.a.Number()
-      limits.longTermUsage.should.be.a.Number()
-      limits.longTermLimit.should.be.above(0).and.be.a.Number()
-    })
-  })
 })

--- a/test/uploads.js
+++ b/test/uploads.js
@@ -15,7 +15,7 @@ describe('uploads_test', function () {
       require('fs').writeFileSync(gpxFilename, gpx, 'utf8')
 
       await new Promise(async (resolve, reject) => {
-        await strava.uploads.post({
+        strava.uploads.post({
           activity_type: 'run',
           sport_type: 'Run',
           data_type: 'gpx',
@@ -31,7 +31,7 @@ describe('uploads_test', function () {
               resolve(payload.activity_id)
             }
           }
-        })
+        }).catch(reject)
       });
     })
   })

--- a/test/uploads.js
+++ b/test/uploads.js
@@ -1,41 +1,38 @@
 require('es6-promise').polyfill()
 
 var should = require('should')
-var strava = require('../')
+const strava = require('../')
 
-describe.skip('uploads_test', function () {
+describe('uploads_test', function () {
   describe('#post()', function () {
-    it('should upload a GPX file', function (done) {
-      this.timeout(30000)
-      new Promise(function (resolve, reject) {
-        strava.uploads.post({
+    it('should upload a GPX file', async () => {
+      // Update datetime in gpx file to now, so Strava doesn't reject it as a duplicate
+      const sampleGpxFilename = 'test/assets/gpx_sample.gpx'
+      const gpxFilename = 'data/gpx_temp.gpx'
+      const now = new Date()
+      let gpx = require('fs').readFileSync(sampleGpxFilename, 'utf8')
+      gpx = gpx.replaceAll(/<time>PLACEHOLDER<\/time>/g, '<time>' + now.toISOString() + '</time>')
+      require('fs').writeFileSync(gpxFilename, gpx, 'utf8')
+
+      await new Promise(async (resolve, reject) => {
+        await strava.uploads.post({
           activity_type: 'run',
           sport_type: 'Run',
           data_type: 'gpx',
           name: 'test activity',
-          file: 'test/assets/gpx_sample.gpx',
+          file: gpxFilename,
           statusCallback: function (err, payload) {
-            should.not.exist(err)
-            should.not.exist(payload.error)
+            if (err) {
+              reject(err);
+            }
 
-            if (payload.activity_id === null) {
-              (payload.status).should.be.exactly('Your activity is still being processed.')
-            } else {
-              (payload.status).should.be.exactly('Your activity is ready.')
+            if (payload.activity_id != null && payload.status == 'Your activity is ready.') {
               payload.activity_id.should.be.a.Number()
-
               resolve(payload.activity_id)
             }
           }
-          // eslint-disable-next-line handle-callback-err
-        }, function (err, payload) {})
-      }).then(function (activityId) {
-        // clean up the uploaded activity
-        strava.activities.delete({ id: activityId }, function (err, payload) {
-          if (err) console.log(err)
-          done()
         })
-      })
+      });
     })
   })
 })


### PR DESCRIPTION
- Moves fully over to async/await for Athlete and Uploads APIs.
  - Resolves https://github.com/node-strava/node-strava-v3/issues/175 for `athlete` and `uploads`
- Updates corresponding tests for Athlete and Uploads APIs
- Updates Uploads tests to use latest datetime in test GPX files since deleting activities is not possible through Strava API anymore
- Fixes issue where remenants of `requests` library was still uses in Uploads API. Resolves `this.request.post is not a function` error

Test results:
```
$ npx mocha test/uploads.js 

  uploads_test
    #post()
      ✔ should upload a GPX file (3391ms)

  1 passing (3s)

$ npx mocha test/athlete.js 

  athlete_test
    #get()
      ✔ should return detailed athlete information about athlete associated to access_token (level 3) (616ms)
    #listActivities()
      ✔ should return information about activities associated to athlete with access_token (268ms)
    #listClubs()
      ✔ should return information about clubs associated to athlete with access_token (745ms)
    #listRoutes()
      ✔ should return information about routes associated to athlete with access_token (698ms)
    #listZones()
      ✔ should return information about heart-rate zones associated to athlete with access_token (319ms)
    #update()
      ✔ should update the weight of the current athlete and revert to original (724ms)

  6 passing (4s)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Public athlete and upload APIs migrated to async/await; methods now return Promises instead of callbacks.

* **New Features**
  * Upload flow supports optional status-callback polling and async progress handling.

* **Bug Fixes**
  * Multipart/form-data uploads set proper headers and response handling; formdata responses parsed alongside JSON.

* **Tests**
  * Tests converted to async/await; GPX times anonymized, upload test uses dynamic timestamp/temp file, and a legacy rate-limits callback test was removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->