### PR TITLE
activities.update update fields need to be wrapped in a body object to be able to update the activity. 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -611,43 +611,43 @@ export interface Lap {
   total_elevation_gain: number;
 }
 
-export type ActivityType = 
-  | "AlpineSki" 
-  | "BackcountrySki" 
-  | "Canoeing" 
-  | "Crossfit" 
-  | "EBikeRide" 
-  | "Elliptical" 
-  | "Golf" 
-  | "Handcycle" 
-  | "Hike" 
-  | "IceSkate" 
-  | "InlineSkate" 
-  | "Kayaking" 
-  | "Kitesurf" 
-  | "NordicSki" 
-  | "Ride" 
-  | "RockClimbing" 
-  | "RollerSki" 
-  | "Rowing" 
-  | "Run" 
-  | "Sail" 
-  | "Skateboard" 
-  | "Snowboard" 
-  | "Snowshoe" 
-  | "Soccer" 
-  | "StairStepper" 
-  | "StandUpPaddling" 
-  | "Surfing" 
-  | "Swim" 
-  | "Velomobile" 
-  | "VirtualRide" 
-  | "VirtualRun" 
-  | "Walk" 
-  | "WeightTraining" 
-  | "Wheelchair" 
-  | "Windsurf" 
-  | "Workout" 
+export type ActivityType =
+  | "AlpineSki"
+  | "BackcountrySki"
+  | "Canoeing"
+  | "Crossfit"
+  | "EBikeRide"
+  | "Elliptical"
+  | "Golf"
+  | "Handcycle"
+  | "Hike"
+  | "IceSkate"
+  | "InlineSkate"
+  | "Kayaking"
+  | "Kitesurf"
+  | "NordicSki"
+  | "Ride"
+  | "RockClimbing"
+  | "RollerSki"
+  | "Rowing"
+  | "Run"
+  | "Sail"
+  | "Skateboard"
+  | "Snowboard"
+  | "Snowshoe"
+  | "Soccer"
+  | "StairStepper"
+  | "StandUpPaddling"
+  | "Surfing"
+  | "Swim"
+  | "Velomobile"
+  | "VirtualRide"
+  | "VirtualRun"
+  | "Walk"
+  | "WeightTraining"
+  | "Wheelchair"
+  | "Windsurf"
+  | "Workout"
   | "Yoga";
 
 export interface DetailedActivity extends SummaryActivity {
@@ -678,14 +678,16 @@ export interface ActivityCreateArgs extends BaseArgs {
 
 export interface ActivityUpdateArgs extends BaseArgs {
   id: string;
-  commute?: boolean;
-  trainer?: boolean;
-  hide_from_home?: boolean;
-  description?: string;
-  name?: string;
-  type?: ActivityType;
-  sport_type?: SportType;
-  gear_id?: string;
+  body: {
+    commute?: boolean;
+    trainer?: boolean;
+    hide_from_home?: boolean;
+    description?: string;
+    name?: string;
+    type?: ActivityType;
+    sport_type?: SportType;
+    gear_id?: string;
+  }
 }
 
 export interface TimedZoneRange {

--- a/lib/activities.js
+++ b/lib/activities.js
@@ -41,8 +41,8 @@ var _updateAllowedProps = [
   'name',
   'type',
   'sport_type',
-  'private',
   'commute',
+  'hide_from_home',
   'trainer',
   'description',
   'gear_id'
@@ -82,7 +82,7 @@ activities.prototype.update = async function (args) {
   _requireActivityId(args);
   _requireActivityUpdateBody(args);
 
-  var form = this.client.getRequestBodyObj(_updateAllowedProps, args)
+  var form = this.client.getRequestBodyObj(_updateAllowedProps, args.body)
   var endpoint = 'activities/' + args.id
 
   args.form = form

--- a/lib/activities.js
+++ b/lib/activities.js
@@ -79,7 +79,8 @@ activities.prototype.create = function (args) {
  * @throws {Error} When args.id is missing
  */
 activities.prototype.update = async function (args) {
-  _requireActivityId(args)
+  _requireActivityId(args);
+  _requireActivityUpdateBody(args);
 
   var form = this.client.getRequestBodyObj(_updateAllowedProps, args)
   var endpoint = 'activities/' + args.id
@@ -149,6 +150,16 @@ activities.prototype.listKudoers = async function (args) {
 var _requireActivityId = function (args) {
   if (typeof args.id === 'undefined') {
     throw new Error('args must include an activity id')
+  }
+}
+/**
+ * Internal: Throws if args does not include a body which is now required for activty update.
+ * @param {{ id?: string; body?: any }} args
+ * @throws {Error} When args.body is missing
+ */
+var _requireActivityUpdateBody = function (args) {
+   if (typeof args.body === 'undefined') {
+    throw new Error('args must include a body')
   }
 }
 /**

--- a/test/activities.js
+++ b/test/activities.js
@@ -112,11 +112,11 @@ describe('activities_test', function () {
 
   describe('#update()', function () {
     it('should update the sport type of an activity', async function () {
-      const sportType = 'MountainBikeRide'
+      const sport_type = 'MountainBikeRide'
       const args = {
         id: testActivity.id,
         body: {
-          sportType: sportType
+          sport_type: sport_type
         }
       }
 
@@ -128,12 +128,12 @@ describe('activities_test', function () {
         .reply(200, {
           id: testActivity.id,
           resource_state: 3,
-          sport_type: sportType
+          sport_type: sport_type
         })
 
       const payload = await strava.activities.update(args)
       assert.strictEqual(payload.resource_state, 3)
-      assert.strictEqual(payload.sport_type, sportType)
+      assert.strictEqual(payload.sport_type, sport_type)
     })
   })
 

--- a/test/activities.js
+++ b/test/activities.js
@@ -88,7 +88,9 @@ describe('activities_test', function () {
       const name = 'Run like the wind!!'
       const args = {
         id: testActivity.id,
-        name: name
+        body: {
+          name: name,
+        }
       }
 
       // Mock the update activity API call
@@ -113,7 +115,9 @@ describe('activities_test', function () {
       const sportType = 'MountainBikeRide'
       const args = {
         id: testActivity.id,
-        sportType: sportType
+        body: {
+          sportType: sportType
+        }
       }
 
       // Mock the update activity API call


### PR DESCRIPTION
activities.update update fields need to be wrapped in a body object to be able to update the activity. 

See https://developers.strava.com/docs/reference/#api-models-UpdatableActivity and https://developers.strava.com/docs/reference/#api-Activities-updateActivityById

Resolved #206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated activity edits to require an update `body` payload.
  * Added clearer validation error when the update payload is missing.

* **Type Updates**
  * Refined activity update argument definitions to nest editable fields under `body`.

* **Behavior Changes**
  * Allowed `hide_from_home` to be included in activity update requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->